### PR TITLE
Add immutability to show and video objects

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -3,21 +3,21 @@ import showData from '$lib/data/shows.json'
 import videoData from '$lib/data/videos.json'
 
 export interface Show {
-	id: string
-	title: string
-	description: string
-	logo?: string | null
-	poster?: string
-	videos: string[]
+	readonly id: string
+	readonly title: string
+	readonly description: string
+	readonly logo?: string | null
+	readonly poster?: string
+	readonly videos: readonly string[]
 }
 
 export interface Video {
-	id: string
-	title: string
-	description: string
-	date: Date
-	show?: string
-	thumbnail?: string
+	readonly id: string
+	readonly title: string
+	readonly description: string
+	readonly date: Date
+	readonly show?: string
+	readonly thumbnail?: string
 }
 
 const shows: { [key: string]: Show } = {}


### PR DESCRIPTION
This adds the `readonly` modifier to all of the `Show` and `Video` properties to ensure nothing is mutated inside a page or component, since these objects are referenced throughout the app. Accidental mutations of data used throughout the app struck me as a likely cause of hard-to-track bugs and this guards against it.